### PR TITLE
Configure docker and containerd before running Ansible

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ trim_trailing_whitespace = true
 spaces_around_operators = true
 spaces_around_brackets = false
 
-[*.{ansible-lint,dockerfilelintrc,ecrc,json,json.j2,rb,yml,yml.j2,yaml,yaml.j2}]
+[*.{ansible-lint,dockerfilelintrc,ecrc,json,json.j2,rb,toml,yml,yml.j2,yaml,yaml.j2}]
 indent_style = space
 indent_size = 2
 

--- a/ansible/files/containerd-config.toml
+++ b/ansible/files/containerd-config.toml
@@ -1,0 +1,250 @@
+disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
+root = "/var/lib/containerd"
+state = "/run/containerd"
+temp = ""
+version = 2
+
+[cgroup]
+  path = ""
+
+[debug]
+  address = ""
+  format = ""
+  gid = 0
+  level = ""
+  uid = 0
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  gid = 0
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_ca = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 0
+
+[metrics]
+  address = ""
+  grpc_histogram = false
+
+[plugins]
+
+  [plugins."io.containerd.gc.v1.scheduler"]
+    deletion_threshold = 0
+    mutation_threshold = 100
+    pause_threshold = 0.02
+    schedule_delay = "0s"
+    startup_delay = "100ms"
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = false
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = true
+    disable_proc_mount = false
+    disable_tcp_service = true
+    enable_selinux = false
+    enable_tls_streaming = false
+    enable_unprivileged_icmp = false
+    enable_unprivileged_ports = false
+    ignore_image_defined_volumes = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "k8s.gcr.io/pause:3.6"
+    selinux_category_range = 1024
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = true
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+      ip_pref = ""
+      max_conf_num = 1
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runc"
+      disable_snapshot_annotations = true
+      discard_unpacked_layers = false
+      ignore_rdt_not_enabled_errors = false
+      no_pivot = false
+      snapshotter = "overlayfs"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = ""
+            CriuImagePath = ""
+            CriuPath = ""
+            CriuWorkPath = ""
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            NoPivotRoot = false
+            Root = ""
+            ShimCgroup = ""
+            SystemdCgroup = true
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+    [plugins."io.containerd.grpc.v1.cri".image_decryption]
+      key_model = "node"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.internal.v1.tracing"]
+    sampling_ratio = 1.0
+    service_name = "containerd"
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+
+  [plugins."io.containerd.runtime.v1.linux"]
+    no_shim = false
+    runtime = "runc"
+    runtime_root = ""
+    shim = "containerd-shim"
+    shim_debug = false
+
+  [plugins."io.containerd.runtime.v2.task"]
+    platforms = ["linux/amd64"]
+    sched_core = false
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+
+  [plugins."io.containerd.service.v1.tasks-service"]
+    rdt_config_file = ""
+
+  [plugins."io.containerd.snapshotter.v1.aufs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.btrfs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    async_remove = false
+    base_image_size = ""
+    discard_blocks = false
+    fs_options = ""
+    fs_type = ""
+    pool_name = ""
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.native"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    root_path = ""
+    upperdir_label = false
+
+  [plugins."io.containerd.snapshotter.v1.zfs"]
+    root_path = ""
+
+  [plugins."io.containerd.tracing.processor.v1.otlp"]
+    endpoint = ""
+    insecure = false
+    protocol = ""
+
+[proxy_plugins]
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.bolt.open" = "0s"
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0

--- a/ansible/files/docker.json
+++ b/ansible/files/docker.json
@@ -1,5 +1,8 @@
 {
-  "exec-opts": ["native.cgroupdriver=systemd"],
+  "exec-opts": [
+    "native.cgroupdriver=systemd"
+  ],
+  "live-restore": true,
   "log-driver": "json-file",
   "log-opts": {
     "max-size": "100m"

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -82,49 +82,4 @@
     name: containerd
     state: started
     enabled: true
-
-- name: Ensure containerd config directory exists.
-  ansible.builtin.file:
-    path: /etc/containerd
-    mode: "0755"
-    state: directory
-  register: containerd_dir
-
-- name: Get defaults from containerd.
-  ansible.builtin.command: containerd config default
-  changed_when: false
-  register: containerd_config_default
-
-- name: Prepare containerd/config.toml from default config
-  ansible.builtin.copy:
-    dest: /tmp/containerd_config.toml
-    content: "{{ containerd_config_default.stdout }}"
-    mode: "0644"
-
-- name: Set Cgroup driver to systemd
-  ansible.builtin.lineinfile:
-    insertafter: '.*\[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options\]$'
-    line: '          SystemdCgroup = true'
-    state: present
-    path: /tmp/containerd_config.toml
-  when: containerd_config_cgroup_driver_systemd
-
-- name: Make sure SystemdCgroup = false is not set
-  ansible.builtin.lineinfile:
-    path: /tmp/containerd_config.toml
-    state: absent
-    line: '            SystemdCgroup = false'
-  notify: restart containerd
-  when: containerd_config_cgroup_driver_systemd
-
-- name: Copy config.toml to /etc/containerd
-  ansible.builtin.copy:
-    remote_src: true
-    src: /tmp/containerd_config.toml
-    dest: /etc/containerd/config.toml
-    mode: "0644"
-  notify: restart containerd
-
-- name: Ensure containerd is restarted immediately if necessary.
-  ansible.builtin.meta: flush_handlers
 ...

--- a/scripts/linux/ci/diagnostics.sh
+++ b/scripts/linux/ci/diagnostics.sh
@@ -146,6 +146,7 @@ host_diagnostics() {
     run_diagnostic_command "pwd" "pwd"
 
     if [ -f /var/run/docker.sock ]; then
+        run_diagnostic_command "containerd" "containerd config dump"
         run_diagnostic_command "docker" "docker info --format '{{json .}}'"
         run_diagnostic_command "docker" "docker --version"
         run_diagnostic_command "docker" "docker -D info"

--- a/scripts/linux/install-docker.sh
+++ b/scripts/linux/install-docker.sh
@@ -38,6 +38,10 @@ else
     wget -qO- https://get.docker.com | sh
     usermod -aG docker "$user"
 
+    # We configure Docker and containerd here and not with Ansible because we run containers as part of the provisioning
+    # and configuration process, so we cannot restart the container engine or containerd daemons
+    # during such process and rely on those containers being up and running.
+
     echo "Copying the Docker daemon configuration files to their destination..."
     mkdir -p /etc/docker
     cp /vagrant/ansible/files/docker.json /etc/docker/daemon.json
@@ -49,5 +53,32 @@ else
     if ! systemctl is-active --quiet docker; then
         echo "Starting the docker service..."
         systemctl start docker
+    else
+        echo "Restarting the docker service..."
+        systemctl restart docker
+    fi
+
+    echo "Copying the containerd configuration files to their destination..."
+    mkdir -p /etc/containerd
+    # Uncommend the following line to regenerate the containerd configuration file from defaults
+    # containerd config default > /vagrant/ansible/files/containerd-config.toml
+    cp /vagrant/ansible/files/containerd-config.toml /etc/containerd/config.toml
+    chmod 0644 /etc/containerd/config.toml
+    chown root:root /etc/containerd/config.toml
+
+    echo "Ensure the containerd service is enabled and running"
+    systemctl enable containerd
+    if ! systemctl is-active --quiet docker; then
+        echo "Starting the containerd service..."
+        systemctl start containerd
+    else
+        echo "Restarting the containerd service..."
+        systemctl restart containerd
     fi
 fi
+
+echo "Getting information about the Docker daemon..."
+docker info
+
+echo "Getting information about containerd config..."
+containerd config dump


### PR DESCRIPTION
This PR moves the configuration of containerd from Ansible to a shell script because, as part of this configuration, we want to restart the `containerd` service, which brings down the container that is running Ansible, causing the whole process to terminate with an error.