### PR TITLE
Fix the configuration process

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,8 @@ necessary packages:
 
 ### Debugging and logs
 
-- Ansible output is saved to `/vagrant/ansible_output.txt`
-- Kubeadm output is saved to `/vagrant/kubedm*.log`
+- Ansible output is saved to `/vagrant/logs/ansible_output.txt`
+- Kubeadm output is saved to `/vagrant/logs/kubedm*.log`
 
 #### Debugging ansible operations
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,12 @@ necessary packages:
 1. (only for headless environments) Manually install Vagrant plugins:
     [scripts/linux/ci/install-vagrant.sh](scripts/linux/ci/install-vagrant.sh)
 
-### Debugging ansible operations
+### Debugging and logs
 
-Ansible output is saved in the `/vagrant/ansible_output.txt`.
+- Ansible output is saved to `/vagrant/ansible_output.txt`
+- Kubeadm output is saved to `/vagrant/kubedm*.log`
+
+#### Debugging ansible operations
 
 For debbugging and development purposes, you can add the verbosity flags in your
 `env.yaml` as follows:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -513,7 +513,7 @@ Vagrant.configure("2") do |config|
         # Ensure password authentication is enabled.
         # We might have to resort to a more secure solution in the future, but
         # for now it's enough.
-        host.vm.provision "password", type:"shell", path: "scripts/linux/enable-ssh-password-authentication.sh"
+        host.vm.provision "password", type: "shell", path: "scripts/linux/enable-ssh-password-authentication.sh"
 
         host.vm.provision "shell" do |s|
           s.path = "scripts/linux/install-kubernetes.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -216,7 +216,8 @@ end
 kubernetes_worker_nodes_count = settings["kubernetes"]["worker_nodes_count"]
 kubernetes_worker_nodes = {}
 
-ansible_controller_vm_name = nil
+# Default to the first master so that we can run Ansible even when there are no worker nodes
+ansible_controller_vm_name = kubernetes_master_1_vm_name
 
 kubernetes_worker_nodes_count.times { |i|
     # Count from 1, to maintain the same behaviour of the static configuration

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -513,7 +513,7 @@ Vagrant.configure("2") do |config|
         # Ensure password authentication is enabled.
         # We might have to resort to a more secure solution in the future, but
         # for now it's enough.
-        host.vm.provision "shell", path: "scripts/linux/enable-ssh-password-authentication.sh"
+        host.vm.provision "password", type:"shell", path: "scripts/linux/enable-ssh-password-authentication.sh"
 
         host.vm.provision "shell" do |s|
           s.path = "scripts/linux/install-kubernetes.sh"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -193,7 +193,9 @@ base_box_builder_cpus = settings["conf"]["base_box_cpus"]
 
 # memory for each host
 base_box_builder_mem = settings["conf"]["base_box_builder_mem"]
+master_cpus = settings["conf"]["master_cpus"]
 master_mem = settings["conf"]["master_mem"]
+minion_cpus = settings["conf"]["minion_cpus"]
 minion_mem = settings["conf"]["minion_mem"]
 
 additional_disk_size = settings["conf"]["additional_disk_size"]
@@ -224,7 +226,7 @@ kubernetes_worker_nodes_count.times { |i|
     kubernetes_worker_nodes[node_id] = {
         autostart: true,
         box: vagrant_x64_kubernetes_nodes_box_id,
-        cpus: 1,
+        cpus: minion_cpus,
         mac_address: node_mac_address,
         mem: minion_mem,
         ip: node_ipv4_address,
@@ -265,7 +267,7 @@ playground = {
     alias: [docker_registry_alias],
     autostart: true,
     box: vagrant_x64_kubernetes_nodes_box_id,
-    cpus: 2,
+    cpus: master_cpus,
     mac_address: master_base_mac_address,
     mem: master_mem,
     ip: kubernetes_master_1_ip,

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -480,6 +480,9 @@ Vagrant.configure("2") do |config|
           vb.name = hostname
         end
       elsif(vagrant_provider == "libvirt")
+        # Vagrant plugins for the libvirt provider
+        config.vagrant.plugins = {"vagrant-libvirt" => {"version" => "0.7.0"}}
+
         host.vm.provider :libvirt do |libvirt|
           libvirt.cpus = info[:cpus]
           libvirt.memory = info[:mem]
@@ -495,6 +498,8 @@ Vagrant.configure("2") do |config|
           end
 
         end
+
+        host.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: "4", nfs_udp: false
       end
       host.vm.hostname = hostname
       if(hostname.include? $base_box_builder_vm_name)
@@ -544,14 +549,11 @@ Vagrant.configure("2") do |config|
             fi
             SCRIPT
         elsif(vagrant_provider == "libvirt")
-            # Vagrant plugins for the libvirt provider
-            config.vagrant.plugins = {"vagrant-libvirt" => {"version" => "0.7.0"}}
-
             $mountNfsShare = <<-"SCRIPT"
             # From now on, we want the script to fail if we have problems mounting the shares
             set -e
             if ! mount | grep -qs /vagrant ; then
-                mount -t nfs -o 'vers=3' $libvirt_management_host_address:$vagrant_root /vagrant
+                mount -t nfs -o 'vers=4' $libvirt_management_host_address:$vagrant_root /vagrant
             fi
             SCRIPT
             $mountNfsShare = $mountNfsShare.gsub("$libvirt_management_host_address", libvirt_management_host_address)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -155,6 +155,8 @@ kubeadm_token = "0y5van.5qxccw2ewiarl68v"
 kubernetes_master_1_ip = network_prefix + master_ipv4_base.to_s
 kubernetes_master_1_ipv6 = network_prefix_ipv6 + settings["net"]["master_ipv6_part"]+ settings["net"]["default_ipv6_host_part"]
 
+kubernetes_version = settings["conf"]["kubernetes_version"]
+
 playground_name = settings["conf"]["playground_name"]
 domain = "." + playground_name + ".local"
 
@@ -366,6 +368,7 @@ default_group_vars = {
   "docker_registry_host" => "#{docker_registry_alias}",
   "kubernetes_master_1_hostname" => "#{kubernetes_master_1_vm_id}",
   "kubernetes_master_1_ip" => "#{kubernetes_master_1_ip}",
+  "kubernetes_version" => "#{kubernetes_version}",
   "kubeadm_token" => "#{kubeadm_token}",
   "subnet_mask_ipv6" => "#{subnet_mask_ipv6}",
   "wildcard_domain" => "#{wildcard_domain}",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -155,7 +155,7 @@ kubeadm_token = "0y5van.5qxccw2ewiarl68v"
 kubernetes_master_1_ip = network_prefix + master_ipv4_base.to_s
 kubernetes_master_1_ipv6 = network_prefix_ipv6 + settings["net"]["master_ipv6_part"]+ settings["net"]["default_ipv6_host_part"]
 
-kubernetes_version = settings["conf"]["kubernetes_version"]
+kubernetes_version = settings["kubernetes"]["kubernetes_version"]
 
 playground_name = settings["conf"]["playground_name"]
 domain = "." + playground_name + ".local"

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -250,7 +250,7 @@
       when:
         - "'kubernetes-masters' in group_names or 'kubernetes-minions' in group_names"
         - kubernetes_node_labels is defined
-        - not kubernetes_network_plugin_options.no-cni-plugin
+        - not kubernetes_network_plugin_options['no-cni-plugin']
   roles:
     - role: kubernetes
       become: true

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -110,6 +110,7 @@
             Kubernetes node labels (all nodes): {{ all_nodes_kubernetes_labels | default([]) }}
             Kubernetes node labels (group): {{ group_kubernetes_labels | default([]) }}
             Kubernetes node labels (to be applied): {{ kubernetes_node_labels }}
+            Kubernetes version to install: {{ kubernetes_version }}
             Machine ID: {{ machine_id | default('NOT DEFINED') }}
             PATH: {{ hostvars[inventory_hostname]['ansible_env']['PATH'] }}
             Service IP CIDR: {{ service_ip_cidr }}

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -250,6 +250,7 @@
       when:
         - "'kubernetes-masters' in group_names or 'kubernetes-minions' in group_names"
         - kubernetes_node_labels is defined
+        - not kubernetes_network_plugin_options.no-cni-plugin
   roles:
     - role: kubernetes
       become: true

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -133,7 +133,7 @@
       become: true
       service:
         state: restarted
-        name: networking
+        name: ifup@eth1.service
       when:
         - add_ipv6_address is changed
     - name: Remove FQDN from 127.0.0.1

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+base_box: false
 containerd_config_cgroup_driver_systemd: false
 kubelet_service_state: started
 ...

--- a/ansible/roles/kubernetes/defaults/main.yml
+++ b/ansible/roles/kubernetes/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 base_box: false
 containerd_config_cgroup_driver_systemd: false
+kubernetes_version: present
 kubelet_service_state: started
 ...

--- a/ansible/roles/kubernetes/tasks/main.yml
+++ b/ansible/roles/kubernetes/tasks/main.yml
@@ -41,6 +41,7 @@
         Base box: {{ base_box }}
         Inventory hostname: {{ inventory_hostname }}
         Kubelet service state: {{ kubelet_service_state }}
+        Kubernetes version: {{ kubernetes_version }}
   ansible.builtin.debug:
     msg: "{{ msg.split('\n') }}"
 
@@ -54,7 +55,7 @@
 - name: Install Kubernetes packages
   ansible.builtin.package:
     name: "{{ item }}"
-    state: present
+    state: "{{ kubernetes_version }}"
   with_items:
     - kubelet
     - kubeadm

--- a/ansible/templates/kubeadm-config.yaml.j2
+++ b/ansible/templates/kubeadm-config.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 bootstrapTokens:
 - groups:
   token: "{{kubeadm_token}}"
@@ -10,7 +10,7 @@ nodeRegistration:
     cgroup-driver: "{{docker_cgroup_driver}}"
     node-ip: "{{ ipv4_address }}"
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 apiServer:
   extraArgs:

--- a/ansible/templates/kubeadm-config.yaml.j2
+++ b/ansible/templates/kubeadm-config.yaml.j2
@@ -15,6 +15,7 @@ kind: ClusterConfiguration
 apiServer:
   extraArgs:
     service-node-port-range: "80-32767"
+kubernetesVersion: "{{kubernetes_version}}"
 networking:
   podSubnet: "{{cluster_ip_cidr}}"
   serviceSubnet: "{{service_ip_cidr}}"

--- a/ansible/templates/kubeadm-config.yaml.j2
+++ b/ansible/templates/kubeadm-config.yaml.j2
@@ -15,7 +15,9 @@ kind: ClusterConfiguration
 apiServer:
   extraArgs:
     service-node-port-range: "80-32767"
+{% if kubernetes_version is defined and kubernetes_version != 'latest' and kubernetes_version != 'present' %}
 kubernetesVersion: "{{kubernetes_version}}"
+{% endif %}
 networking:
   podSubnet: "{{cluster_ip_cidr}}"
   serviceSubnet: "{{service_ip_cidr}}"

--- a/ansible/templates/kubeadm-config.yaml.j2
+++ b/ansible/templates/kubeadm-config.yaml.j2
@@ -15,8 +15,6 @@ kind: ClusterConfiguration
 apiServer:
   extraArgs:
     service-node-port-range: "80-32767"
-featureGates:
-  IPv6DualStack: true
 networking:
   podSubnet: "{{cluster_ip_cidr}}"
   serviceSubnet: "{{service_ip_cidr}}"

--- a/ansible/templates/kubeadm-config.yaml.j2
+++ b/ansible/templates/kubeadm-config.yaml.j2
@@ -21,3 +21,7 @@ kubernetesVersion: "{{kubernetes_version}}"
 networking:
   podSubnet: "{{cluster_ip_cidr}}"
   serviceSubnet: "{{service_ip_cidr}}"
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+cgroupDriver: systemd

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -44,7 +44,7 @@ kubernetes:
   # If set to true, allows scheduling pods on master nodes.
   allow_workloads_on_masters: false
   # Kubernetes version to install
-  kubernetes_version: "v1.24.2"
+  kubernetes_version: "present"
   # Number of master nodes to provision
   # we currently support only one master node
   master_nodes_count: 1

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -43,6 +43,8 @@ conf:
 kubernetes:
   # If set to true, allows scheduling pods on master nodes.
   allow_workloads_on_masters: false
+  # Kubernetes version to install
+  kubernetes_version: "v1.24.2"
   # Number of master nodes to provision
   # we currently support only one master node
   master_nodes_count: 1

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -13,8 +13,12 @@ conf:
   base_box_builder_mem: 2048
   # Number of CPUs assigned to the base box.
   base_box_cpus: 2
+  # Number of CPUs assigned to master nodes.
+  master_cpus: 2
   # RAM memory assigned to master nodes.
   master_mem: 2048
+  # Number of CPUs assigned to minion nodes.
+  minion_cpus: 1
   # RAM memory assigned to worker nodes.
   minion_mem: 1024
   # DNS domain name of the playground.

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/linux/bootstrap-kubernetes-master.sh
+++ b/scripts/linux/bootstrap-kubernetes-master.sh
@@ -21,13 +21,13 @@ chown vagrant:vagrant /home/vagrant/.kube
 chown vagrant:vagrant /home/vagrant/.kube/config
 
 for i in 1 2 3 4 5; do
-  echo "Trying to connect to the Kubernetes cluster API server with kubectl. Tentative: ${i}"
-  if kubectl get nodes; then
-    break
-  else
-    echo "The Kubernetes API server is not available. Waiting for a bit and retrying."
-    sleep 15
-  fi
+    echo "Trying to connect to the Kubernetes cluster API server with kubectl. Tentative: ${i}"
+    if kubectl get nodes; then
+        break
+    else
+        echo "The Kubernetes API server is not available. Waiting for a bit and retrying."
+        sleep 15
+    fi
 done
 
 network_plugin_id="$2"

--- a/scripts/linux/bootstrap-kubernetes-master.sh
+++ b/scripts/linux/bootstrap-kubernetes-master.sh
@@ -7,7 +7,7 @@ configuration_file_path="$1"
 _HOSTNAME="$(hostname)"
 
 echo "Initializing this node, ($_HOSTNAME) which is a master with configuration file: $configuration_file_path. Contents: $(cat "$configuration_file_path")"
-kubeadm init --config "$configuration_file_path" 2>&1 | tee /vagrant/kubeadm-init-master.log
+kubeadm init --config "$configuration_file_path" 2>&1 | tee /vagrant/logs/kubeadm-init-master.log
 
 # Setup root user environment
 mkdir -p "$HOME"/.kube

--- a/scripts/linux/bootstrap-kubernetes-master.sh
+++ b/scripts/linux/bootstrap-kubernetes-master.sh
@@ -11,14 +11,24 @@ kubeadm init --config "$configuration_file_path"
 
 # Setup root user environment
 mkdir -p "$HOME"/.kube
-cp -i /etc/kubernetes/admin.conf "$HOME"/.kube/config
+cp /etc/kubernetes/admin.conf "$HOME"/.kube/config
 chown "$(id -u)":"$(id -g)" "$HOME"/.kube/config
 
 # Setup vagrant user environment
 mkdir -p /home/vagrant/.kube
-cp -i /etc/kubernetes/admin.conf /home/vagrant/.kube/config
+cp /etc/kubernetes/admin.conf /home/vagrant/.kube/config
 chown vagrant:vagrant /home/vagrant/.kube
 chown vagrant:vagrant /home/vagrant/.kube/config
+
+for i in 1 2 3 4 5; do
+  echo "Trying to connect to the Kubernetes cluster API server with kubectl. Tentative: ${i}"
+  if kubectl get nodes; then
+    break
+  else
+    echo "The Kubernetes API server is not available. Waiting for a bit and retrying."
+    sleep 15
+  fi
+done
 
 network_plugin_id="$2"
 echo "Installing $network_plugin_id network plugin"

--- a/scripts/linux/bootstrap-kubernetes-master.sh
+++ b/scripts/linux/bootstrap-kubernetes-master.sh
@@ -7,7 +7,7 @@ configuration_file_path="$1"
 _HOSTNAME="$(hostname)"
 
 echo "Initializing this node, ($_HOSTNAME) which is a master with configuration file: $configuration_file_path. Contents: $(cat "$configuration_file_path")"
-kubeadm init --config "$configuration_file_path"
+kubeadm init --config "$configuration_file_path" 2>&1 | tee /vagrant/kubeadm-init-master.log
 
 # Setup root user environment
 mkdir -p "$HOME"/.kube

--- a/scripts/linux/bootstrap-kubernetes-minion.sh
+++ b/scripts/linux/bootstrap-kubernetes-minion.sh
@@ -23,7 +23,7 @@ fi
 
 if [ "$network_plugin_id" != 'no-cni-plugin' ]; then
     echo "Initializing Kubernetes minion to join: $master_address and token: $token"
-    kubeadm join "$master_address":6443 --token "$token" --discovery-token-unsafe-skip-ca-verification 2>&1 | tee /vagrant/kubeadm-init-worker.log
+    kubeadm join "$master_address":6443 --token "$token" --discovery-token-unsafe-skip-ca-verification 2>&1 | tee /vagrant/logs/kubeadm-init-worker.log
 fi
 
 set +e

--- a/scripts/linux/bootstrap-kubernetes-minion.sh
+++ b/scripts/linux/bootstrap-kubernetes-minion.sh
@@ -23,7 +23,7 @@ fi
 
 if [ "$network_plugin_id" != 'no-cni-plugin' ]; then
     echo "Initializing Kubernetes minion to join: $master_address and token: $token"
-    kubeadm join "$master_address":6443 --token "$token" --discovery-token-unsafe-skip-ca-verification
+    kubeadm join "$master_address":6443 --token "$token" --discovery-token-unsafe-skip-ca-verification 2>&1 | tee /vagrant/kubeadm-init-worker.log
 fi
 
 set +e

--- a/scripts/linux/enable-ssh-password-authentication.sh
+++ b/scripts/linux/enable-ssh-password-authentication.sh
@@ -34,7 +34,7 @@ unset SSH_CONFIG_FILE_PATH
 
 VAGRANT_USER_NAME="vagrant"
 VAGRANT_USER_PASSWORD="vagrant"
-echo "Ensure the $VAGRANT_USER_NAME user has a known password (user: $VAGRANT_USER_NAME, password: $VAGRANT_USER_PASSWORD"
+echo "Ensure the $VAGRANT_USER_NAME user has a known password (user: $VAGRANT_USER_NAME, password: $VAGRANT_USER_PASSWORD)"
 usermod --password "$(openssl passwd -1 "$VAGRANT_USER_PASSWORD")" "$VAGRANT_USER_NAME"
 unset VAGRANT_USER_NAME
 unset VAGRANT_USER_PASSWORD

--- a/scripts/linux/install-kubernetes.sh
+++ b/scripts/linux/install-kubernetes.sh
@@ -49,7 +49,7 @@ playbooks="$kubernetes_playbook_path"
 ANSIBLE_DOCKER_IMAGE_DIRECTORY_PATH=/vagrant/docker/ansible
 ANSIBLE_DOCKER_IMAGE_TAG="ferrarimarco/kubernetes-playground-ansible"
 echo "Building the Docker image to run Ansible."
-docker build --rm --tag "$ANSIBLE_DOCKER_IMAGE_TAG" --file="$ANSIBLE_DOCKER_IMAGE_DIRECTORY_PATH"/Dockerfile "$ANSIBLE_DOCKER_IMAGE_DIRECTORY_PATH"
+docker build --tag "$ANSIBLE_DOCKER_IMAGE_TAG" --file="$ANSIBLE_DOCKER_IMAGE_DIRECTORY_PATH"/Dockerfile "$ANSIBLE_DOCKER_IMAGE_DIRECTORY_PATH"
 unset ANSIBLE_DOCKER_IMAGE_DIRECTORY_PATH
 
 echo "Installing python-apt..."

--- a/scripts/linux/install-kubernetes.sh
+++ b/scripts/linux/install-kubernetes.sh
@@ -66,7 +66,7 @@ docker run --rm \
     --net=host \
     "$ANSIBLE_DOCKER_IMAGE_TAG" \
     /bin/sh -c "ansible-playbook -i $inventory $additional_ansible_arguments $playbooks" \
-    2>&1 | tee /vagrant/ansible_output.txt
+    2>&1 | tee /vagrant/logs/ansible_output.txt
 
 unset ANSIBLE_DOCKER_IMAGE_TAG
 


### PR DESCRIPTION
This PR does the following:

- Set the NFS version to 4 both using the Vagrant built-in sharing feature and in the script that the `mount-shared` provisioner runs. This is to comply with NFS clients that removed support for NFSv3.
- Move the `vagrant-libvirt` plugin configuration where all the VMs can make use of that, and not just the VMs that aren't the "base VM".
- Add a name to the enable-ssh-password-auth script so it's callable from vagrant provision --provision-with
- Add a missing default value for the base_box variable
- Add a missing ) to the echo when setting the vagrant user password
- Fix restarting the network service
- Remove deprecated IPv6DualStack feature gate
- Support configuring CPUs of nodes
- Update kubeadm config files to beta3
- Make the kubernetes bootstrap script more robust by checking if kubectl works before applying changes
- Don't add labels to nodes when not adding worker nodes to the cluster
- Save kubeadm logs
- Support setting the Kubernetes version to install
- Support running Ansible even when there are no worker nodes