### PR TITLE
Fix IPv6 address assignment on Debian Bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ it.
     through Vagrant. This is useful when you've issues connecting with
     `vagrant ssh`.
 
+### Development notes
+
+#### Network configuration
+
+- Debian Bullseye (server installations and cloud images) uses ifup and ifdown to manage network interfaces.
+- ifup and ifdown rely on `/etc/network/interfaces` (and related) configuration file.
+- Systemd invokes ifup and ifdown via the `networking.service` unit.
+- ifup and ifdown don't interact with interfaces that are missing the `auto <INTERFACE_NAME>` directive in `/etc/network/interfaces`.
+
 ## Contributing
 
 Contributions to this project are welcome! See the instructions in

--- a/README.md
+++ b/README.md
@@ -256,9 +256,11 @@ it.
 
 ### Development notes
 
+In this section, we list findings and notes that we found useful during development.
+
 #### Network configuration
 
-- Debian Bullseye (server installations and cloud images) uses ifup and ifdown to manage network interfaces.
+- Debian Bullseye (server and cloud images) uses ifup and ifdown to manage network interfaces.
 - ifup and ifdown rely on `/etc/network/interfaces` (and related) configuration file.
 - Systemd invokes ifup and ifdown via the `networking.service` unit.
 - ifup and ifdown don't interact with interfaces that are missing the `auto <INTERFACE_NAME>` directive in `/etc/network/interfaces`.

--- a/ansible/kubernetes.yml
+++ b/ansible/kubernetes.yml
@@ -117,11 +117,30 @@
             Subnet mask IPv6: {{ subnet_mask_ipv6 }}
       debug:
         msg: "{{ msg.split('\n') }}"
+    # So that the Vagrant control network interface restarts when restarting the networking service
+    - name: Add the autoconfiguration directive for the Vagrant control network interface
+      become: true
+      lineinfile:
+        path: /etc/network/interfaces
+        line: "auto eth0"
+        owner: root
+        group: root
+        mode: "0644"
     - name: Add the autoconfiguration directive for {{ additional_network_interface_name }}
       become: true
       lineinfile:
         path: /etc/network/interfaces
         line: "auto {{ additional_network_interface_name }}"
+        owner: root
+        group: root
+        mode: "0644"
+      when:
+        - additional_network_interface_name is defined
+    - name: Add the allow-hotplug directive for {{ additional_network_interface_name }}
+      become: true
+      lineinfile:
+        path: /etc/network/interfaces
+        line: "allow-hotplug {{ additional_network_interface_name }}"
         owner: root
         group: root
         mode: "0644"
@@ -144,7 +163,7 @@
       become: true
       service:
         state: restarted
-        name: ifup@eth1.service
+        name: networking.service
       when:
         - add_ipv6_address is changed
     - name: Remove FQDN from 127.0.0.1


### PR DESCRIPTION
This PR fixes an issue that we had after updating to Debian Bullseye. I added some reasoning in the README.

TLDR: When restarting the `ifup@eth1` service, we didn't run the complete network initialization. For that, we needed to restart the `networking` service instead, but we'd lose IP addresses on the Vagrant control network interface.

To fix this, I added the `auto eth0` directive in `/etc/network/interfaces`, so that we can rely on ifup/down (and so on the `networking` service) again.